### PR TITLE
ci: Remove armv7 builds

### DIFF
--- a/.github/workflows/node-red.yml
+++ b/.github/workflows/node-red.yml
@@ -39,4 +39,3 @@ jobs:
           platforms: |
             linux/amd64
             linux/arm64/v8
-            linux/arm/v7    


### PR DESCRIPTION
armv7 is no longer supported by Docker official images (from Node 24)